### PR TITLE
Added appropriate cities to README, and local linting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,31 @@
 # Where to Eat?
 
-Places that we like to eat at.
+Places at which we like to eat :knife_fork_plate:
 
 This repository has places to eat for the following cities:
 
 * [Boulder, CO](/locations/boulder)
-* [Vernon Hills](/locations/Vernon Hills)
-* [Thai Thani, FL](/locations/Orlando/Thai-Thani.md)
+* [Chicago, IL](/locations/Chicago)
+* [Hyderabad, Telangana](/locations/Hyderabad)
+* [Newport Beach, CA](/locations/Newport Beach)
+* [Orlando, FL](/locations/Orlando)
+* [The Woodlands, TX](/locations/The Woodlands)
+* [Vernon Hills, IL](/locations/Vernon Hills)
 
 ## Contributing
 
-If you would like to add a place to eat, please ensure you follow the following
-instructions.
+If you would like to add a place to eat, please ensure you follow the following instructions.
 
 * Your addition should be a Markdown text file with the extension `.md`.
 * Your addition should be located somewhere within the
   [./locations](/locations/) directory.
 * Your addition should be in the format specified by the
   [`PLACE_TO_EAT_TEMPLATE.md`](./PLACE_TO_EAT_TEMPLATE.md) template.
+
+## Linting
+
+To run the linter locally, use the following command:
+
+  ```sh
+  python lint_markdown_files.py PLACE_TO_EAT_TEMPLATE.md locations/
+  ```


### PR DESCRIPTION
### What was wrong?

Cities were missing from README, and linting instructions would be great to have in the main README.

### How was it fixed?

Addid Cities, linting insturctions.

#### Cute Animal Picture

![](http://i.giphy.com/QpOZPQQ2wbjOM.gif)

