### PR TITLE
Southlake in directory but not located in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository has places to eat for the following cities:
 * [Newport Beach, CA](/locations/Newport Beach)
 * [Orlando, FL](/locations/Orlando)
 * [Seattle, WA](/locations/Seattle)
+* [Southlake, TX](/locations/Southlake)
 * [The Woodlands, TX](/locations/The Woodlands)
 * [Vernon Hills, IL](/locations/Vernon Hills)
 


### PR DESCRIPTION
### What was wrong?
Southlake, TX had it's own directory located in (./locations) but it was not added to the README file.


### How was it fixed?
Southlake, TX is now added and functionally in the README file.


#### Cute Animal Picture

![image](http://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-10.jpg)

